### PR TITLE
Don't warn if "Emacs" in the package summary is followed by "Lisp"

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -295,7 +295,10 @@ DESC is a struct as returned by `package-buffer-info'."
        1 1
        'warning
        "The package summary is too long. It should be at most 50 characters.")))
-    (when (string-match-p "\\<[Ee]macs\\>" summary)
+    (when (save-match-data
+            (let ((case-fold-search t))
+              (and (string-match "\\<emacs\\>" summary)
+                   (not (string-match-p "[[:space:]]+lisp" summary (match-end 0))))))
       (flypkg/error
        1 1
        'warning


### PR DESCRIPTION
Making it a PR because I'm not sure if we want it.

To me, it's a good idea, because while "Emacs" is obvious and thus always redundant, "Emacs Lisp" is not. A good example would be [auto-compile](http://melpa.org/#/auto-compile), which has a pretty generic name, but is Emacs Lisp specific, so it's right for the summary to specify it's Emacs Lisp, er, specific.

What's your thoughts?