### PR TITLE
Fix emacs 24.3 compatibility

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -43,6 +43,12 @@
 (require 'lisp-mnt)
 
 
+;;; Compatibility
+
+(unless (fboundp 'package-desc-summary)
+  (defalias 'package-desc-summary 'package-desc-doc))
+
+
 ;;; Machinery
 
 (defun flypkg/start (checker callback)


### PR DESCRIPTION
In older versions of emacs `package-desc-summary` was called `package-desc-doc` [[commit](http://git.savannah.gnu.org/cgit/emacs.git/diff/lisp/emacs-lisp/package.el?h=f56be016d5d2d550f98c83a9d4e61468c71738c2)]. Use an alias so flycheck-package works under older versions of emacs.

Tested under emacs 24.3.