### PR TITLE
Don't skip some checks if no packages are required

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -105,12 +105,11 @@ This is bound dynamically while the checks run.")
                line-no 1 'error
                "More than one expression provided."))
             (let ((deps (flycheck-package--check-well-formed-dependencies position line-no parsed-deps)))
-              (when deps
-                (flycheck-package--check-packages-installable deps)
-                (flycheck-package--check-deps-use-non-snapshot-version deps)
-                (flycheck-package--check-deps-do-not-use-zero-versions deps)
-                (flycheck-package--check-lexical-binding-requires-emacs-24 deps)
-                (flycheck-package--check-do-not-depend-on-cl-lib-1.0 deps))))
+              (flycheck-package--check-packages-installable deps)
+              (flycheck-package--check-deps-use-non-snapshot-version deps)
+              (flycheck-package--check-deps-do-not-use-zero-versions deps)
+              (flycheck-package--check-lexical-binding-requires-emacs-24 deps)
+              (flycheck-package--check-do-not-depend-on-cl-lib-1.0 deps)))
         (error
          (flycheck-package--error
           line-no 1 'error


### PR DESCRIPTION
The current usage of `(when deps ...)` makes `flycheck-package` skip some checks when the `Package-Requires` section is empty. This is because `(if '() 'foo 'bar)` evaluates to `'bar`.

As an example, without this fix, flycheck-package won't warn about lexical-binding being used if the Package-Requires is simply `()`.

Here's an example of a simple package that reproduces the issue if this fix is not applied. `flycheck-package` doesn't warn about `lexical-binding` being used.

    ;;; foo.el --- baz -*- lexical-binding: t -*-

    ;;; Copyright (C) 2016 Omair Majid

    ;; Author: Omair Majid <omair.majid@mail.com>
    ;; URL: foo
    ;; License: Public Domain
    ;; Keywords: foo
    ;; Version: 0.1.20160917
    ;; Package-Requires: ()

    ;;; Commentary:

    ;; 

    ;;; Code:


    (provide 'foo)
    ;;; foo.el ends here
