### PR TITLE
Accept functions whose name is the package prefix

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -423,7 +423,7 @@ DESC is a struct as returned by `package-buffer-info'."
 (defun flycheck-package--check-defs-prefix (definitions)
   "Verify that symbol DEFINITIONS start with package prefix."
   (let* ((prefix (flycheck-package--get-package-prefix))
-         (prefix-re (concat "\\`" prefix "-")))
+         (prefix-re (rx-to-string `(seq string-start ,prefix (or "-" string-end)))))
     (when prefix
       (pcase-dolist (`(,name . ,position) definitions)
         (unless (string-match-p prefix-re name)


### PR DESCRIPTION
If a function's name is the same as the package's name/prefix, it would be marked as an error.  This allows such functions.  I overlooked this when submitting this function before.  D: