### PR TITLE
Make sure to add next-checker chain from emacs-lisp flycheck checker

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -67,8 +67,16 @@
 Add `flycheck-emacs-lisp-package' to `flycheck-checkers'."
   (interactive)
   (add-to-list 'flycheck-checkers 'emacs-lisp-package t)
-  (flycheck-add-next-checker 'emacs-lisp 'emacs-lisp-package t)
-  (flycheck-add-next-checker 'emacs-lisp-checkdoc 'emacs-lisp-package t))
+  (let ((visited '(emacs-lisp-package))
+        recurfn)
+    (setq recurfn
+          (lambda (elm)
+            (push elm visited)
+            (flycheck-add-next-checker elm 'emacs-lisp-package t)
+            (dolist (checker (flycheck-get-next-checkers elm))
+              (unless (memq checker visited)
+                (funcall recurfn checker)))))
+    (funcall recurfn 'emacs-lisp)))
 
 (provide 'flycheck-package)
 ;;; flycheck-package.el ends here


### PR DESCRIPTION
Hi!
I found flycheck issue to add `next-checker`. See discussion at https://github.com/flycheck/flycheck/issues/1660
Modified to be the most appropriate method at this time.