### PR TITLE
Move package-lint-looks-like-a-package-p to checker predicate

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -48,8 +48,7 @@
             (mapcar (lambda (x)
                       (apply #'flycheck-error-new-at `(,@x :checker ,checker)))
                     (condition-case err
-                        (when (package-lint-looks-like-a-package-p)
-                          (package-lint-buffer (current-buffer)))
+                        (package-lint-buffer (current-buffer))
                       (error
                        (funcall callback 'errored (error-message-string err))
                        (signal (car err) (cdr err))))))))
@@ -60,6 +59,7 @@
 (flycheck-define-generic-checker 'emacs-lisp-package
   "A checker for \"Package-Requires\" headers and other packaging issues."
   :start #'flycheck-package--start
+  :predicate #'package-lint-looks-like-a-package-p
   :modes '(emacs-lisp-mode))
 
 ;;;###autoload


### PR DESCRIPTION
So `flycheck-verify-setup` and `flycheck-verify-checker` will show
whether `'emacs-lisp-package` may run.
